### PR TITLE
Filter builder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,72 +2,83 @@ import { useState } from "react";
 import { run } from "./logic/run";
 import Result from "./components/Result";
 import Code from "./components/Code";
+import { FilterBuilder } from "./components/FilterBuilder/FilterBuilder";
 
 export function App() {
   const [filter, setFilter] = useState(textExamples[0].value);
-  const ast = run(filter);
+  const expr = run(filter);
 
   return (
-    <div style={{ width: "800px", margin: "auto" }}>
-      <main>
+    <div style={{ width: "1200px", margin: "auto" }}>
+      <header>
         <h1>OGC CQL2 Filters playground</h1>
-        <section>
-          <div style={{ display: "flex", flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
-            <h2>CQL2 text or JSON</h2>
-            <select
-              onChange={(evt) => {
-                let selected = evt.target.value;
-                // try to apply formatting to JSON
-                if (selected.startsWith("{")) {
-                  try {
-                    selected = JSON.stringify(JSON.parse(selected), null, 2);
-                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                  } catch (error) {
-                    // don't care
-                  }
-                }
-                setFilter(selected);
-              }}
-              style={{ display: "inline-block" }}
+      </header>
+      <main style={{ display: "flex", flexDirection: "row", gap: "16px" }}>
+        <section id="input-output">
+          <section>
+            <div
+              style={{ display: "flex", flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}
             >
-              <option disabled>Choose example</option>
-              <optgroup label="Text Expressions">
-                {textExamples.map(({ value, label }, index) => (
-                  <option key={index} label={label}>
-                    {value}
-                  </option>
-                ))}
-              </optgroup>
-              <optgroup label="JSON Expressions">
-                {JSONExamples.map(({ value, label }, index) => (
-                  <option key={index} label={label}>
-                    {value}
-                  </option>
-                ))}
-              </optgroup>
-            </select>
-          </div>
-          <textarea
-            value={filter}
-            onChange={(evt) => {
-              setFilter(evt.target.value);
-            }}
-            placeholder="Type CQL2 text expression"
-            style={{ width: "99%" }}
-            rows={12}
-            spellCheck={false}
-          />
+              <h2>CQL2 text or JSON</h2>
+              <select
+                onChange={(evt) => {
+                  let selected = evt.target.value;
+                  // try to apply formatting to JSON
+                  if (selected.startsWith("{")) {
+                    try {
+                      selected = JSON.stringify(JSON.parse(selected), null, 2);
+                      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    } catch (error) {
+                      // don't care
+                    }
+                  }
+                  setFilter(selected);
+                }}
+                style={{ display: "inline-block" }}
+              >
+                <option disabled>Choose example</option>
+                <optgroup label="Text Expressions">
+                  {textExamples.map(({ value, label }, index) => (
+                    <option key={index} label={label}>
+                      {value}
+                    </option>
+                  ))}
+                </optgroup>
+                <optgroup label="JSON Expressions">
+                  {JSONExamples.map(({ value, label }, index) => (
+                    <option key={index} label={label}>
+                      {value}
+                    </option>
+                  ))}
+                </optgroup>
+              </select>
+            </div>
+            <textarea
+              value={filter}
+              onChange={(evt) => {
+                setFilter(evt.target.value);
+              }}
+              placeholder="Type CQL2 text expression"
+              style={{ width: "99%" }}
+              rows={12}
+              spellCheck={false}
+            />
+          </section>
+          <section>
+            <h2>Results:</h2>
+            <div style={{ display: "flex", flexDirection: "row", gap: "16px" }}>
+              <Result title="Text">
+                <Code>{expr.toText()}</Code>
+              </Result>
+              <Result title="JSON">
+                <Code>{JSON.stringify(expr.toJSON(), null, 2)}</Code>
+              </Result>
+            </div>
+          </section>
         </section>
-        <section>
-          <h2>Results:</h2>
-          <div style={{ display: "flex", flexDirection: "row", gap: "16px" }}>
-            <Result title="Text">
-              <Code>{ast.toText()}</Code>
-            </Result>
-            <Result title="JSON">
-              <Code>{JSON.stringify(ast.toJSON(), null, 2)}</Code>
-            </Result>
-          </div>
+        <section id="builder">
+          <h2>Filter Builder</h2>
+          <FilterBuilder expr={expr} />
         </section>
       </main>
       <hr />

--- a/src/components/FilterBuilder/FilterBuilder.tsx
+++ b/src/components/FilterBuilder/FilterBuilder.tsx
@@ -1,0 +1,130 @@
+import { ChangeEvent, ReactNode } from "react";
+import {
+  BinaryExpression,
+  Expression,
+  ExpressionVisitor,
+  FunctionExpression,
+  GroupingExpression,
+  IsNullOperatorExpression,
+  LiteralExpression,
+  OperatorExpression,
+  PropertyExpression,
+  UnaryExpression,
+} from "../../logic/Entities/Expression";
+
+const logEvent = (e: ChangeEvent<HTMLSelectElement | HTMLInputElement>) => {
+  console.log(e.target.value);
+};
+
+const ReactVisitor: ExpressionVisitor<ReactNode> = {
+  visitBinaryExpression(expr: BinaryExpression): ReactNode {
+    return (
+      <>
+        {expr.left.accept(ReactVisitor)} {expr.operator.accept(ReactVisitor)} {expr.right.accept(ReactVisitor)}
+      </>
+    );
+  },
+
+  visitGroupingExpression(expr: GroupingExpression): ReactNode {
+    return <>( {expr.expression.accept(ReactVisitor)} )</>;
+  },
+
+  visitLiteralExpression(expr: LiteralExpression): ReactNode {
+    switch (expr.literalPair.type) {
+      case "string":
+      case "number": {
+        return <input type={expr.literalPair.type} value={expr.literalPair.value} onChange={logEvent} />;
+      }
+
+      case "boolean": {
+        return (
+          <select value={expr.literalPair.value.toString()} onChange={logEvent}>
+            <option value={true.toString()}>True</option>
+            <option value={false.toString()}>False</option>
+          </select>
+        );
+      }
+
+      case "date":
+      case "timestamp": {
+        const { type, value } = LiteralExpression.getDateValue(expr.literalPair);
+        if (type === "date") {
+          return <input type="date" value={value} onChange={logEvent} />;
+        }
+
+        return <input type="datetime-local" value={value.split("Z")[0]} onChange={logEvent} />;
+      }
+
+      case "null": {
+        return <>null</>;
+      }
+    }
+  },
+
+  visitUnaryExpression(expr: UnaryExpression): ReactNode {
+    return (
+      <>
+        {expr.operator.accept(ReactVisitor)}
+        {expr.right.accept(ReactVisitor)}
+      </>
+    );
+  },
+
+  visitFunctionExpression(expr: FunctionExpression): ReactNode {
+    return (
+      <>
+        {expr.operator.accept(ReactVisitor)}( {expr.args.map((arg) => arg.accept(ReactVisitor))} )
+      </>
+    );
+  },
+
+  visitPropertyExpression(expr: PropertyExpression): ReactNode {
+    return <input type="text" defaultValue={expr.toText()} onChange={logEvent} />;
+  },
+
+  visitOperatorExpression(expr: OperatorExpression): ReactNode {
+    const arithmeticOpe = ["+", "-", "*", "/"];
+    const logicalOps = ["<", ">", ">=", "<=", "=", "<>"];
+
+    if (arithmeticOpe.includes(expr.toText())) {
+      return (
+        <select value={expr.toText()} onChange={logEvent}>
+          {arithmeticOpe.map((op) => (
+            <option key={op} value={op}>
+              {op}
+            </option>
+          ))}
+        </select>
+      );
+    } else if (logicalOps.includes(expr.toText())) {
+      return (
+        <select value={expr.toText()} onChange={logEvent}>
+          {logicalOps.map((op) => (
+            <option key={op} value={op}>
+              {op}
+            </option>
+          ))}
+        </select>
+      );
+    }
+
+    return <input type="text" value={expr.toText()} />;
+  },
+
+  visitIsNullOperatorExpression(expr: IsNullOperatorExpression): ReactNode {
+    return (
+      <select value={expr.isNot.toString()} onChange={logEvent}>
+        <option value={true.toString()}>is null</option>
+        <option value={false.toString()}>is not null</option>
+      </select>
+    );
+  },
+};
+
+interface FilterRendererProps {
+  expr: Expression;
+}
+
+export function FilterBuilder({ expr }: FilterRendererProps) {
+  return expr.accept(ReactVisitor);
+}

--- a/src/logic/run.ts
+++ b/src/logic/run.ts
@@ -1,11 +1,11 @@
+import type { Expression } from "./Entities/Expression";
 import parseJSON from "./parser/parseJSON";
 import parseText from "./parser/parseText";
 import scanText from "./scanner/scanText";
-import { Serializable } from "./types";
 
 type InputType = string | object;
 
-export function run(input: InputType): Serializable {
+export function run(input: InputType): Expression {
   try {
     if (typeof input === "object") {
       return parseJSON(input);
@@ -24,6 +24,7 @@ export function run(input: InputType): Serializable {
     return {
       toText: () => message,
       toJSON: () => message,
-    };
+      accept: () => message,
+    } as Expression;
   }
 }

--- a/src/logic/types.ts
+++ b/src/logic/types.ts
@@ -40,13 +40,8 @@ export interface TimestampLiteral extends LiteralBase {
   value: Date;
   type: "timestamp";
 }
-export type LiteralPair =
-  | StringLiteral
-  | NumberLiteral
-  | BooleanLiteral
-  | NullLiteral
-  | CalendarDateLiteral
-  | TimestampLiteral;
+export type TimeLiteral = CalendarDateLiteral | TimestampLiteral;
+export type LiteralPair = StringLiteral | NumberLiteral | BooleanLiteral | NullLiteral | TimeLiteral;
 
 // https://docs.ogc.org/is/21-065r2/21-065r2.html#basic-cql2_property
 export interface PropertyRef<T extends Scalar> {


### PR DESCRIPTION
Filter builder using visitor pattern. 
Rationale: There are many things we could do to the expression AST. It's possible to use visitor pattern to render to JSON, Text, React, HTML, validation, etc. For Text and JSON I wanted it to be "first class" built in implementation, without requiring anything external. For renderers and validators, it's possible to use the AST using the accept method.

In this PR, you can see a React Visitor that transforms AST to React