### PR TITLE
And, Or, Not

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:coverage": "vitest run --coverage",
     "test:once": "vitest run",
     "test": "vitest",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --build --noEmit"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/src/logic/Entities/Expression.test.ts
+++ b/src/logic/Entities/Expression.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import * as Expressions from "./Expression";
 import parseText from "../parser/parseText";
 import scanText from "../scanner/scanText";
+import Token from "./Token";
 
 describe("Test Expressions", () => {
   describe("Test visitor", () => {
@@ -107,6 +108,14 @@ describe("Test Expressions", () => {
         name: "booleans",
         input: "TRUE<>FALSE",
       },
+      {
+        name: "and",
+        input: "foo AND bar",
+      },
+      {
+        name: "or",
+        input: "foo OR bar",
+      },
     ];
 
     test.each(tests)("Visit $name", ({ input }) => {
@@ -118,14 +127,15 @@ describe("Test Expressions", () => {
   describe("Test immutability", () => {
     const tests = Object.values(Expressions).map((Expr) => ({
       name: Expr.name,
-      // @ts-expect-error because instantiate without arguments
-      expr: new Expr(),
+      // @ts-expect-error because instantiate without right number of arguments
+      expr: new Expr(new Token(0, "NOT", "NOT")),
     }));
 
     test.each(tests)("$name is immutable", ({ name, expr }) => {
       expect(() => {
         expr.toText = () => "foo";
       }).toThrow("Cannot add property toText, object is not extensible");
+
       expect(() => {
         expr.toJSON = () => "bar";
       }).toThrow("Cannot add property toJSON, object is not extensible");

--- a/src/logic/Entities/Expression.test.ts
+++ b/src/logic/Entities/Expression.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "vitest";
-import * as Expressions from "./Expression";
 import parseText from "../parser/parseText";
 import scanText from "../scanner/scanText";
+import * as Expressions from "./Expression";
 import Token from "./Token";
+import { Arity, operatorMetadata } from "./operatorMetadata";
 
 describe("Test Expressions", () => {
   describe("Test visitor", () => {
@@ -146,6 +147,35 @@ describe("Test Expressions", () => {
           expr[key] = "baz";
         }).toThrow(`Cannot assign to read only property '${key}' of object '#<${name}>'`);
       }
+    });
+  });
+
+  describe("Test operator expressions metadata getter", () => {
+    test("OperatorExpression", () => {
+      const opExpr = new Expressions.OperatorExpression(new Token(11, "PLUS", "+"));
+      const meta = operatorMetadata.get("PLUS");
+
+      for (const key in meta) {
+        // @ts-expect-error ts doesn't like "arbitrary" key access
+        expect(opExpr[key]).toBe(meta[key]);
+      }
+    });
+
+    test("IsNullOperatorExpression", () => {
+      const expr = new Expressions.PropertyExpression("abc");
+      const isNullExpr = new Expressions.IsNullOperatorExpression(expr, false);
+      expect(isNullExpr.text).toBe("is null");
+      expect(isNullExpr.json).toBe("isNull");
+      expect(isNullExpr.label).toBe("is null");
+      expect(isNullExpr.arity).toBe(Arity.Unary);
+      expect(isNullExpr.notation).toBe("postfix");
+
+      const isNotNullExpr = new Expressions.IsNullOperatorExpression(expr, true);
+      expect(isNotNullExpr.text).toBe("is not null");
+      expect(isNotNullExpr.json).toBe("is not null");
+      expect(isNotNullExpr.label).toBe("is not null");
+      expect(isNotNullExpr.arity).toBe(Arity.Unary);
+      expect(isNotNullExpr.notation).toBe("postfix");
     });
   });
 });

--- a/src/logic/Entities/Expression.ts
+++ b/src/logic/Entities/Expression.ts
@@ -22,12 +22,13 @@ export interface Expression extends Serializable {
  * Good for negation, ex "-3", or "not null" and other prefix
  */
 export class UnaryExpression implements Expression {
-  operator: OperatorExpression;
-  right: Expression;
+  readonly operator: OperatorExpression;
+  readonly right: Expression;
 
   constructor(operator: OperatorExpression, right: Expression) {
     this.operator = operator;
     this.right = right;
+    Object.freeze(this);
   }
 
   toText() {
@@ -50,14 +51,15 @@ export class UnaryExpression implements Expression {
  * Good for comparison operators and other infix operators
  */
 export class BinaryExpression implements Expression {
-  left: Expression;
-  operator: OperatorExpression;
-  right: Expression;
+  readonly left: Expression;
+  readonly operator: OperatorExpression;
+  readonly right: Expression;
 
   constructor(left: Expression, operator: OperatorExpression, right: Expression) {
     this.left = left;
     this.operator = operator;
     this.right = right;
+    Object.freeze(this);
   }
 
   toText() {
@@ -78,12 +80,13 @@ export class BinaryExpression implements Expression {
  * Good for... functions
  */
 export class FunctionExpression implements Expression {
-  operator: OperatorExpression;
-  args: Expression[];
+  readonly operator: OperatorExpression;
+  readonly args: Expression[];
 
   constructor(operator: OperatorExpression, args: Expression[]) {
     this.operator = operator;
     this.args = args;
+    Object.freeze(this);
   }
 
   toText() {
@@ -100,10 +103,11 @@ export class FunctionExpression implements Expression {
 }
 
 export class GroupingExpression implements Expression {
-  expression: Expression;
+  readonly expression: Expression;
 
   constructor(expression: Expression) {
     this.expression = expression;
+    Object.freeze(this);
   }
 
   toText() {
@@ -123,10 +127,11 @@ export class GroupingExpression implements Expression {
 // #region Atomic expressions
 // literals, property, etc
 export class LiteralExpression implements Expression {
-  literalPair: LiteralPair;
+  readonly literalPair: LiteralPair;
 
   constructor(literalPair: LiteralPair) {
     this.literalPair = literalPair;
+    Object.freeze(this);
   }
 
   toText() {
@@ -154,7 +159,6 @@ export class LiteralExpression implements Expression {
   }
 
   // Date helpers
-  // Date helpers
   static getDateValue(literalPair: TimeLiteral): DateValuePair {
     const date = literalPair.value.toISOString();
     return {
@@ -175,10 +179,11 @@ interface DateValuePair {
 }
 
 export class PropertyExpression implements Expression {
-  name: string;
+  readonly name: string;
 
   constructor(name: string) {
     this.name = name;
+    Object.freeze(this);
   }
 
   toText() {
@@ -195,8 +200,8 @@ export class PropertyExpression implements Expression {
 }
 
 export class OperatorExpression implements Expression, OperatorMeta {
-  operator: string;
-  #meta: OperatorMeta;
+  readonly operator: string;
+  readonly #meta: OperatorMeta;
 
   static getMetadata(operator: string): OperatorMeta {
     return (
@@ -213,6 +218,7 @@ export class OperatorExpression implements Expression, OperatorMeta {
   constructor(operator: string) {
     this.operator = operator;
     this.#meta = OperatorExpression.getMetadata(this.operator);
+    Object.freeze(this);
   }
 
   toText() {
@@ -239,12 +245,13 @@ export class OperatorExpression implements Expression, OperatorMeta {
 }
 
 export class IsNullOperatorExpression implements Expression, OperatorMeta {
-  expression: Expression;
-  isNot: boolean;
+  readonly expression: Expression;
+  readonly isNot: boolean;
 
   constructor(expression: Expression, isNot: boolean) {
     this.expression = expression;
     this.isNot = isNot;
+    Object.freeze(this);
   }
 
   toText() {

--- a/src/logic/Entities/Expression.ts
+++ b/src/logic/Entities/Expression.ts
@@ -291,7 +291,8 @@ export class IsNullOperatorExpression implements Expression, OperatorMeta {
     return this.isNot ? "is not null" : "is null";
   }
   get json() {
-    return this.isNot ? "is not null" : "is null";
+    // TODO what to replace with "is not null" ?
+    return this.isNot ? "is not null" : "isNull";
   }
   get label() {
     return this.isNot ? "is not null" : "is null";

--- a/src/logic/Entities/Token.test.ts
+++ b/src/logic/Entities/Token.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import Token from "./Token";
+
+describe("Test Token", () => {
+  test("Tokens are serializable", () => {
+    const token = new Token(3, "TRUE", "true", true);
+    expect(token.toText()).toStrictEqual("TRUE true true");
+    expect(token.toJSON()).toStrictEqual({
+      charIndex: 3,
+      type: "TRUE",
+      lexeme: "true",
+      literal: true,
+    });
+  });
+
+  describe("Test immutability", () => {
+    test("Tokens are immutable", () => {
+      const token = new Token(2, "NOT_EQUAL", "<>");
+
+      expect(() => {
+        token.toText = () => "foo";
+      }).toThrow("Cannot add property toText, object is not extensible");
+
+      expect(() => {
+        token.toJSON = () => token.toJSON();
+      }).toThrow("Cannot add property toJSON, object is not extensible");
+
+      for (const key in token) {
+        expect(() => {
+          // @ts-expect-error because assigning to implicit any
+          token[key] = "baz";
+        }).toThrow(`Cannot assign to read only property '${key}' of object '#<Token>'`);
+      }
+    });
+  });
+});

--- a/src/logic/Entities/Token.ts
+++ b/src/logic/Entities/Token.ts
@@ -1,17 +1,36 @@
 import type { Literal, Serializable } from "../types";
 import type { TokenType } from "./TokenType";
 
+/**
+ * Token object represents a single "word" in CQL2.
+ */
 export default class Token implements Serializable {
+  /**
+   * The first index of the lexeme.
+   */
   readonly charIndex: number;
+
+  /**
+   * Type of the token.
+   */
   readonly type: TokenType;
+
   /**
    * Lexemes are only the raw substrings of the source code, including quotations.
-   * ex. add (function identifier), "Berlin" (string, wrapped with string quotes), 1.23 (string)
+   * @example TRUE (string)
+   * @example 'Berlin' (string, wrapped with string quotes)
+   * @example 1.23 (digits as string)
+   * @example DIV (function identifier as string)
    */
   readonly lexeme: string;
+
   /**
    * Literals are identifiers, strings, or numbers. These are values.
-   * ex. add (function identifier as string), Berlin (string), 1.23 (number)
+   * If literal is not provided, the lexeme will be used.
+   * @example true (boolean)
+   * @example Berlin (string, without wrapping quotes)
+   * @example 1.23 (number)
+   * @example DIV (function identifier)
    */
   readonly literal: Literal;
 

--- a/src/logic/Entities/Token.ts
+++ b/src/logic/Entities/Token.ts
@@ -1,5 +1,5 @@
 import type { Literal, Serializable } from "../types";
-import type TokenType from "./TokenType";
+import type { TokenType } from "./TokenType";
 
 export default class Token implements Serializable {
   readonly charIndex: number;

--- a/src/logic/Entities/Token.ts
+++ b/src/logic/Entities/Token.ts
@@ -2,24 +2,25 @@ import type { Literal, Serializable } from "../types";
 import type TokenType from "./TokenType";
 
 export default class Token implements Serializable {
-  charIndex: number;
-  type: TokenType;
+  readonly charIndex: number;
+  readonly type: TokenType;
   /**
    * Lexemes are only the raw substrings of the source code, including quotations.
    * ex. add (function identifier), "Berlin" (string, wrapped with string quotes), 1.23 (string)
    */
-  lexeme: string;
+  readonly lexeme: string;
   /**
    * Literals are identifiers, strings, or numbers. These are values.
    * ex. add (function identifier as string), Berlin (string), 1.23 (number)
    */
-  literal: Literal;
+  readonly literal: Literal;
 
   constructor(charIndex: number, type: TokenType, lexeme: string, literal?: Literal) {
     this.type = type;
     this.lexeme = lexeme;
     this.literal = literal ?? lexeme;
     this.charIndex = charIndex;
+    Object.freeze(this);
   }
 
   toText() {

--- a/src/logic/Entities/TokenType.ts
+++ b/src/logic/Entities/TokenType.ts
@@ -1,4 +1,25 @@
-type TokenType =
+export type OperatorTokenType =
+  // Tokens with one character
+  | "MINUS" // -
+  | "PLUS" // +
+  | "STAR" // *
+  | "SLASH" // /
+  | "EQUAL" // =
+
+  // Tokens with one or two characters
+  | "GREATER" // >
+  | "GREATER_EQUAL" // >=
+  | "LESS" // <
+  | "LESS_EQUAL" // <=
+  | "NOT_EQUAL" // <>
+
+  // Keywords
+  | "AND" // AND
+  | "OR"; // OR
+
+export type TokenType =
+  | OperatorTokenType
+
   // Tokens with one character
   | "LEFT_PAREN" // (
   | "RIGHT_PAREN" // )
@@ -15,18 +36,13 @@ type TokenType =
   | "SLASH" // /
   | "EQUAL" // =
 
-  // Tokens with one or two characters
-  | "GREATER" // >
-  | "GREATER_EQUAL" // >=
-  | "LESS" // <
-  | "LESS_EQUAL" // <=
-  | "NOT_EQUAL" // <>
-
   // Keywords
   | "TRUE" // TRUE
   | "FALSE" // FALSE
   | "TIMESTAMP" // timestamp | TIMESTAMP
   | "DATE" // date | DATE
+
+  // Tokens IS NOT NULL are not considered operators (at least for now)
   | "IS"
   | "NOT"
   | "NULL"
@@ -38,5 +54,3 @@ type TokenType =
 
   // That's all, folks
   | "EOF";
-
-export default TokenType;

--- a/src/logic/Entities/TokenType.ts
+++ b/src/logic/Entities/TokenType.ts
@@ -14,8 +14,9 @@ export type OperatorTokenType =
   | "NOT_EQUAL" // <>
 
   // Keywords
-  | "AND" // AND
-  | "OR"; // OR
+  | "AND"
+  | "OR"
+  | "NOT";
 
 export type TokenType =
   | OperatorTokenType
@@ -42,9 +43,8 @@ export type TokenType =
   | "TIMESTAMP" // timestamp | TIMESTAMP
   | "DATE" // date | DATE
 
-  // Tokens IS NOT NULL are not considered operators (at least for now)
+  // Tokens IS and NULL are not considered operators (at least for now)
   | "IS"
-  | "NOT"
   | "NULL"
 
   // Literals

--- a/src/logic/Entities/operatorMetadata.ts
+++ b/src/logic/Entities/operatorMetadata.ts
@@ -57,6 +57,17 @@ const operatorMetadataObj: Record<OperatorTokenType, OperatorMeta> = {
     // minArgs: 2,
     // maxArgs: Infinity,
   },
+  NOT: {
+    text: "NOT",
+    json: "not",
+    label: "not",
+    notation: "prefix",
+    arity: Arity.Unary,
+    // outputType: "boolean",
+    // inputTypes: ["boolean"],
+    // minArgs: 1,
+    // maxArgs: 1,
+  },
   // #endregion
 
   // #region comparison operators

--- a/src/logic/Entities/operatorMetadata.ts
+++ b/src/logic/Entities/operatorMetadata.ts
@@ -1,4 +1,4 @@
-// import type { LiteralType } from "./types";
+import { OperatorTokenType } from "./TokenType";
 
 export enum Arity {
   Variadic,
@@ -11,9 +11,20 @@ export type Notation = "prefix" | "infix" | "postfix";
 // type InputOutputType = LiteralType | "unknown"; // unknown used for functions, and can't be validated
 
 export interface OperatorMeta {
+  /** How operator appears in CQL2 Text */
+  text: string;
+  /** How operator appears in CQL2 JSON */
+  json: string;
+
+  /** Human readable string */
   label: string;
+
+  /** Number of operands the operator takes */
   arity: Arity;
-  notation: Notation; // for CQL Text
+
+  /** For CQL2 Text */
+  notation: Notation;
+
   // outputType: InputOutputType;
   // inputTypes: InputOutputType[];
   // minArgs: number;
@@ -22,40 +33,37 @@ export interface OperatorMeta {
 
 // const allInputTypes: InputOutputType[] = ["null", "boolean", "number", "string", "date", "timestamp"] as const;
 
-export const operatorMetadata: Record<string, OperatorMeta> = {
+const operatorMetadataObj: Record<OperatorTokenType, OperatorMeta> = {
   // #region logical operators
-  and: {
+  AND: {
+    text: "AND",
+    json: "and",
     label: "and",
     notation: "infix",
-    arity: Arity.Variadic,
+    arity: Arity.Binary,
     // outputType: "boolean",
     // inputTypes: ["boolean"],
     // minArgs: 2,
     // maxArgs: Infinity,
   },
-  or: {
+  OR: {
+    text: "OR",
+    json: "or",
     label: "or",
     notation: "infix",
-    arity: Arity.Variadic,
+    arity: Arity.Binary,
     // outputType: "boolean",
     // inputTypes: ["boolean"],
     // minArgs: 2,
     // maxArgs: Infinity,
-  },
-  not: {
-    label: "not",
-    arity: Arity.Unary,
-    notation: "infix",
-    // outputType: "boolean",
-    // inputTypes: ["boolean"],
-    // minArgs: 1,
-    // maxArgs: 1,
   },
   // #endregion
 
   // #region comparison operators
   // https://docs.ogc.org/DRAFTS/21-065.html#advanced-comparison-operators
-  "=": {
+  EQUAL: {
+    text: "=",
+    json: "=",
     label: "equal",
     arity: Arity.Binary,
     notation: "infix",
@@ -64,43 +72,56 @@ export const operatorMetadata: Record<string, OperatorMeta> = {
     // minArgs: 2,
     // maxArgs: 2,
   },
-  "<>": {
+  NOT_EQUAL: {
+    text: "<>",
+    json: "<>",
     label: "not equal to",
     arity: Arity.Binary,
     notation: "infix",
     // outputType: "boolean",
     // inputTypes: allInputTypes,
   },
-  isNull: {
-    label: "is null",
-    arity: Arity.Unary,
-    notation: "postfix",
-    // outputType: "boolean",
-    // inputTypes: allInputTypes,
-    // maxArgs: 1,
-  },
-  "<": {
+  // isNull: {
+  //   text: "isNul",
+  //   json: "",
+  //   label: "is null",
+  //   arity: Arity.Unary,
+  //   notation: "postfix",
+  //   // outputType: "boolean",
+  //   // inputTypes: allInputTypes,
+  //   // maxArgs: 1,
+  // },
+  LESS: {
+    text: "<",
+    json: "<",
     label: "less than",
     arity: Arity.Binary,
     notation: "infix",
     // outputType: "boolean",
     // inputTypes: ["number"],
   },
-  "<=": {
+  LESS_EQUAL: {
+    text: "<=",
+    json: "<=",
     label: "less than or equal to",
     arity: Arity.Binary,
     notation: "infix",
     // outputType: "boolean",
     // inputTypes: ["number"],
   },
-  ">": {
+  GREATER: {
+    text: ">",
+    json: ">",
+
     label: "greater than",
     arity: Arity.Binary,
     notation: "infix",
     // outputType: "boolean",
     // inputTypes: ["number"],
   },
-  ">=": {
+  GREATER_EQUAL: {
+    text: ">=",
+    json: ">=",
     label: "greater than or equal to",
     arity: Arity.Binary,
     notation: "infix",
@@ -111,60 +132,76 @@ export const operatorMetadata: Record<string, OperatorMeta> = {
 
   // #region arithmetic operators
   // https://docs.ogc.org/DRAFTS/21-065.html#arithmetic
-  "+": {
+  PLUS: {
+    text: "+",
+    json: "+",
     label: "addition",
     arity: Arity.Binary,
     notation: "infix",
     // outputType: "number",
     // inputTypes: ["number"],
   },
-  "-": {
+  MINUS: {
+    text: "-",
+    json: "-",
     label: "subtraction",
     arity: Arity.Binary,
     notation: "infix", // TODO
     // outputType: "number",
     // inputTypes: ["number"],
   },
-  "*": {
+  STAR: {
+    text: "*",
+    json: "*",
     label: "multiplication",
     arity: Arity.Binary,
     notation: "infix",
     // outputType: "number",
     // inputTypes: ["number"],
   },
-  "/": {
+  SLASH: {
+    text: "/",
+    json: "/",
     label: "division",
     arity: Arity.Binary,
     notation: "infix",
     // outputType: "number",
     // inputTypes: ["number"],
   },
-  "%": {
-    label: "modulo",
-    arity: Arity.Binary,
-    notation: "infix",
-    // outputType: "number",
-    // inputTypes: ["number"],
-  },
-  div: {
-    label: "integer division",
-    arity: Arity.Binary,
-    notation: "infix",
-    // outputType: "number",
-    // inputTypes: ["number"],
-  },
-  "^": {
-    label: "exponention",
-    arity: Arity.Binary,
-    notation: "infix",
-    // outputType: "number",
-    // inputTypes: ["number"],
-  },
+  // "%": {
+  //   text: "%",
+  //   json: "%",
+  //   label: "modulo",
+  //   arity: Arity.Binary,
+  //   notation: "infix",
+  //   // outputType: "number",
+  //   // inputTypes: ["number"],
+  // },
+  // div: {
+  //   text: "DIV",
+  //   json: "div",
+  //   label: "integer division",
+  //   arity: Arity.Binary,
+  //   notation: "infix",
+  //   // outputType: "number",
+  //   // inputTypes: ["number"],
+  // },
+  // "^": {
+  //   text: "^",
+  //   json: "^",
+  //   label: "exponention",
+  //   arity: Arity.Binary,
+  //   notation: "infix",
+  //   // outputType: "number",
+  //   // inputTypes: ["number"],
+  // },
   // #endregion
 
   // #region advanced comparison operators
   // https://docs.ogc.org/DRAFTS/21-065.html#advanced-comparison-operators
   // like: {
+  //   text: null,
+  //   json: null,
   //   label: "like",
   //   arity: Arity.Binary,
   //   notation: "infix",
@@ -172,6 +209,8 @@ export const operatorMetadata: Record<string, OperatorMeta> = {
   //   inputTypes: ["number"], // TODO
   // },
   // between: {
+  //   text: null,
+  //   json: null,
   //   label: "between",
   //   arity: Arity.Ternary,
   //   outputType: "boolean",
@@ -180,6 +219,8 @@ export const operatorMetadata: Record<string, OperatorMeta> = {
   //   // maxArgs: 3,
   // },
   // in: {
+  //   text: null,
+  //   json: null,
   //   label: "in",
   //   arity: Arity.Binary,
   //   outputType: "boolean",
@@ -187,3 +228,7 @@ export const operatorMetadata: Record<string, OperatorMeta> = {
   // },
   // #endregion
 };
+
+export const operatorMetadata = new Map<OperatorTokenType, OperatorMeta>(
+  Object.entries(operatorMetadataObj) as [OperatorTokenType, OperatorMeta][],
+);

--- a/src/logic/parser/parseJSON.test.ts
+++ b/src/logic/parser/parseJSON.test.ts
@@ -261,13 +261,13 @@ describe("Test parsing tokens (text)", () => {
     },
     {
       name: "args is not an array",
-      input: { op: 3, args: false },
-      message: `Failed to parse expression: expected op to be of type string, found type number in node '{"op":3,"args":false}'`,
+      input: { op: "-", args: true },
+      message: `Failed to parse expression: expected args to be an array, in node '{"op":"-","args":true}'`,
     },
     {
-      name: "args is not an array (nested)",
-      input: { op: "+", args: [5, { op: true, args: null }] },
-      message: `Failed to parse expression: expected op to be of type string, found type boolean in node '{"op":true,"args":null}'`,
+      name: "op is not a string (nested)",
+      input: { op: "*", args: [5, { op: "%", args: 123 }] },
+      message: `Failed to parse expression: expected args to be an array, in node '{"op":"%","args":123}'`,
     },
   ];
 

--- a/src/logic/parser/parseJSON.test.ts
+++ b/src/logic/parser/parseJSON.test.ts
@@ -204,6 +204,22 @@ describe("Test parsing tokens (text)", () => {
         json: { op: "or", args: [{ op: "and", args: ["foo", "bar"] }, "baz"] },
       },
     },
+    {
+      name: "negation",
+      input: { op: "not", args: ["a"] },
+      expected: {
+        text: "NOT 'a'",
+        json: { op: "not", args: ["a"] },
+      },
+    },
+    {
+      name: "complex negation",
+      input: { op: "and", args: ["a", { op: "not", args: ["b"] }] },
+      expected: {
+        text: "'a' AND NOT 'b'",
+        json: { op: "and", args: ["a", { op: "not", args: ["b"] }] },
+      },
+    },
   ];
 
   test.each(tests)("Parse with $name", ({ input, expected }) => {

--- a/src/logic/parser/parseJSON.test.ts
+++ b/src/logic/parser/parseJSON.test.ts
@@ -230,6 +230,16 @@ describe("Test parsing tokens (text)", () => {
 
   const invalidTests = [
     {
+      name: "undefined",
+      input: undefined,
+      message: "Failed to parse: node's value is 'undefined'",
+    },
+    {
+      name: "undefined (nested)",
+      input: { op: "a", args: [undefined] },
+      message: "Failed to parse: node's value is 'undefined'",
+    },
+    {
       name: "missing op",
       input: {},
       message: `Failed to parse expression: expected op in node '{}'`,

--- a/src/logic/parser/parseJSON.test.ts
+++ b/src/logic/parser/parseJSON.test.ts
@@ -8,7 +8,7 @@ describe("Test parsing tokens (text)", () => {
       name: "Empty, just EOF",
       input: "",
       expected: {
-        string: "",
+        text: "",
         json: "",
       },
     },
@@ -16,7 +16,7 @@ describe("Test parsing tokens (text)", () => {
       name: "number",
       input: 123,
       expected: {
-        string: "123",
+        text: "123",
         json: 123,
       },
     },
@@ -24,7 +24,7 @@ describe("Test parsing tokens (text)", () => {
       name: "decimal number",
       input: 123.456,
       expected: {
-        string: "123.456",
+        text: "123.456",
         json: 123.456,
       },
     },
@@ -32,15 +32,15 @@ describe("Test parsing tokens (text)", () => {
       name: "negative number",
       input: -456,
       expected: {
-        string: "-456",
+        text: "-456",
         json: -456,
       },
     },
     {
-      name: "string (wrapped in quotes)",
+      name: "string (not wrapped in quotes)",
       input: "hello world",
       expected: {
-        string: "hello world",
+        text: "'hello world'",
         json: "hello world",
       },
     },
@@ -48,7 +48,7 @@ describe("Test parsing tokens (text)", () => {
       name: "addition",
       input: { op: "+", args: [3, 4] },
       expected: {
-        string: "3 + 4",
+        text: "3 + 4",
         json: { op: "+", args: [3, 4] },
       },
     },
@@ -56,7 +56,7 @@ describe("Test parsing tokens (text)", () => {
       name: "calendar date",
       input: { date: "1999-11-05" },
       expected: {
-        string: "DATE('1999-11-05')",
+        text: "DATE('1999-11-05')",
         json: { date: "1999-11-05" },
       },
     },
@@ -64,7 +64,7 @@ describe("Test parsing tokens (text)", () => {
       name: "timestamp",
       input: { timestamp: "1999-01-15T13:45:23.000Z" },
       expected: {
-        string: "TIMESTAMP('1999-01-15T13:45:23.000Z')",
+        text: "TIMESTAMP('1999-01-15T13:45:23.000Z')",
         json: { timestamp: "1999-01-15T13:45:23.000Z" },
       },
     },
@@ -72,7 +72,7 @@ describe("Test parsing tokens (text)", () => {
       name: "arithmetic",
       input: { op: "+", args: [{ op: "*", args: [3, 1] }, 2] },
       expected: {
-        string: "3 * 1 + 2",
+        text: "3 * 1 + 2",
         json: { op: "+", args: [{ op: "*", args: [3, 1] }, 2] },
       },
     },
@@ -81,7 +81,7 @@ describe("Test parsing tokens (text)", () => {
       input: { op: "add", args: [4, 5] },
       expected: {
         json: { op: "add", args: [4, 5] },
-        string: "add(4, 5)",
+        text: "add(4, 5)",
       },
     },
     {
@@ -89,14 +89,14 @@ describe("Test parsing tokens (text)", () => {
       input: { op: "avg", args: [{ property: "windSpeed" }] },
       expected: {
         json: { op: "avg", args: [{ property: "windSpeed" }] },
-        string: "avg(windSpeed)",
+        text: "avg(windSpeed)",
       },
     },
     {
       name: "comparison with property",
       input: { op: ">=", args: [{ property: "cloudCoverage" }, 50] },
       expected: {
-        string: "cloudCoverage >= 50",
+        text: "cloudCoverage >= 50",
         json: { op: ">=", args: [{ property: "cloudCoverage" }, 50] },
       },
     },
@@ -104,7 +104,7 @@ describe("Test parsing tokens (text)", () => {
       name: "comparison with property other direction",
       input: { op: ">=", args: [50, { property: "cloudCoverage" }] },
       expected: {
-        string: "50 >= cloudCoverage",
+        text: "50 >= cloudCoverage",
         json: { op: ">=", args: [50, { property: "cloudCoverage" }] },
       },
     },
@@ -112,7 +112,7 @@ describe("Test parsing tokens (text)", () => {
       name: "arithmetic has higher precedence than comparisons",
       input: { op: ">=", args: [{ property: "cloudCoverage" }, { op: "+", args: [10, 20] }] },
       expected: {
-        string: "cloudCoverage >= 10 + 20",
+        text: "cloudCoverage >= 10 + 20",
         json: { op: ">=", args: [{ property: "cloudCoverage" }, { op: "+", args: [10, 20] }] },
       },
     },
@@ -120,7 +120,7 @@ describe("Test parsing tokens (text)", () => {
       name: "arithmetic has higher precedence than comparisons other direction",
       input: { op: ">=", args: [{ op: "+", args: [10, 20] }, { property: "cloudCoverage" }] },
       expected: {
-        string: "10 + 20 >= cloudCoverage",
+        text: "10 + 20 >= cloudCoverage",
         json: { op: ">=", args: [{ op: "+", args: [10, 20] }, { property: "cloudCoverage" }] },
       },
     },
@@ -128,7 +128,7 @@ describe("Test parsing tokens (text)", () => {
       name: "equal",
       input: { op: "=", args: [3, { op: "+", args: [2, 1] }] },
       expected: {
-        string: "3 = 2 + 1",
+        text: "3 = 2 + 1",
         json: { op: "=", args: [3, { op: "+", args: [2, 1] }] },
       },
     },
@@ -136,7 +136,7 @@ describe("Test parsing tokens (text)", () => {
       name: "not equal",
       input: { op: "<>", args: [4, 5] },
       expected: {
-        string: "4 <> 5",
+        text: "4 <> 5",
         json: { op: "<>", args: [4, 5] },
       },
     },
@@ -144,7 +144,7 @@ describe("Test parsing tokens (text)", () => {
       name: "booleans",
       input: { op: "<>", args: [true, false] },
       expected: {
-        string: "TRUE <> FALSE",
+        text: "TRUE <> FALSE",
         json: { op: "<>", args: [true, false] },
       },
     },
@@ -152,7 +152,7 @@ describe("Test parsing tokens (text)", () => {
       name: "is null",
       input: { op: "isNull", args: [{ property: "geometry" }] },
       expected: {
-        string: "geometry IS NULL",
+        text: "geometry IS NULL",
         json: { op: "isNull", args: [{ property: "geometry" }] },
       },
     },
@@ -160,15 +160,47 @@ describe("Test parsing tokens (text)", () => {
       name: "is not null",
       input: { op: "not", args: [{ op: "isNull", args: [{ property: "geometry" }] }] },
       expected: {
-        string: "geometry IS NOT NULL",
+        text: "geometry IS NOT NULL",
         json: { op: "not", args: [{ op: "isNull", args: [{ property: "geometry" }] }] },
+      },
+    },
+    {
+      name: "and",
+      input: { op: "and", args: [{ property: "foo" }, { property: "bar" }] },
+      expected: {
+        text: "foo AND bar",
+        json: { op: "and", args: [{ property: "foo" }, { property: "bar" }] },
+      },
+    },
+    {
+      name: "or",
+      input: { op: "or", args: [{ property: "foo" }, { property: "bar" }] },
+      expected: {
+        text: "foo OR bar",
+        json: { op: "or", args: [{ property: "foo" }, { property: "bar" }] },
+      },
+    },
+    {
+      name: "precedence - or before and",
+      input: { op: "or", args: ["foo", { op: "and", args: ["bar", "baz"] }] },
+      expected: {
+        text: "'foo' OR 'bar' AND 'baz'",
+        json: { op: "or", args: ["foo", { op: "and", args: ["bar", "baz"] }] },
+      },
+    },
+    {
+      name: "precedence - and before or",
+      input: { op: "or", args: [{ op: "and", args: ["foo", "bar"] }, "baz"] },
+      expected: {
+        text: "'foo' AND 'bar' OR 'baz'",
+        json: { op: "or", args: [{ op: "and", args: ["foo", "bar"] }, "baz"] },
       },
     },
   ];
 
   test.each(tests)("Parse with $name", ({ input, expected }) => {
     const parsed = parseJSON(input);
-    expect(parsed.toText()).toStrictEqual(expected.string);
+    expect(parsed.toText()).toStrictEqual(expected.text);
     expect(parsed.toJSON()).toStrictEqual(expected.json);
   });
 

--- a/src/logic/parser/parseJSON.test.ts
+++ b/src/logic/parser/parseJSON.test.ts
@@ -149,6 +149,14 @@ describe("Test parsing tokens (text)", () => {
       },
     },
     {
+      name: "just null",
+      input: null,
+      expected: {
+        text: "NULL",
+        json: null,
+      },
+    },
+    {
       name: "is null",
       input: { op: "isNull", args: [{ property: "geometry" }] },
       expected: {

--- a/src/logic/parser/parseJSON.ts
+++ b/src/logic/parser/parseJSON.ts
@@ -15,7 +15,7 @@ import { JSONPath } from "../types";
 import ParseJSONError from "./ParseJSONError";
 
 export default function parseJSON(json: unknown): Expression {
-  return mapJSONtoExpression(json);
+  return mapJSONtoExpression(json, []);
 
   /**
    * Map input JSON to Expression
@@ -25,7 +25,7 @@ export default function parseJSON(json: unknown): Expression {
    * @param {{string | number}[]} path
    * @returns {Expression}
    */
-  function mapJSONtoExpression(node: unknown, path: JSONPath = []): Expression {
+  function mapJSONtoExpression(node: unknown, path: JSONPath): Expression {
     if (node === null) return new LiteralExpression({ value: node, type: "null" });
     if (typeof node === "boolean") return new LiteralExpression({ value: node, type: "boolean" });
     if (typeof node === "number") return new LiteralExpression({ value: node, type: "number" });

--- a/src/logic/parser/parseJSON.ts
+++ b/src/logic/parser/parseJSON.ts
@@ -96,6 +96,10 @@ export default function parseJSON(json: unknown): Expression {
       }
       // #endregion
     }
+    if (node === undefined) {
+      throw new ParseJSONError(path, "Failed to parse: node's value is 'undefined'");
+    }
+
     throw new ParseJSONError(path, "Failed to parse");
   }
 

--- a/src/logic/parser/parseText.test.ts
+++ b/src/logic/parser/parseText.test.ts
@@ -126,6 +126,22 @@ describe("Test parsing tokens (text)", () => {
       },
     },
     {
+      name: "negation",
+      input: "NOT 'a'",
+      expected: {
+        text: "NOT 'a'",
+        json: { op: "not", args: ["a"] },
+      },
+    },
+    {
+      name: "complex negation",
+      input: "'a' AND NOT 'b'",
+      expected: {
+        text: "'a' AND NOT 'b'",
+        json: { op: "and", args: ["a", { op: "not", args: ["b"] }] },
+      },
+    },
+    {
       name: "calendar date",
       input: "DATE('1999-11-05')",
       expected: {

--- a/src/logic/parser/parseText.test.ts
+++ b/src/logic/parser/parseText.test.ts
@@ -102,6 +102,14 @@ describe("Test parsing tokens (text)", () => {
       },
     },
     {
+      name: "just null",
+      input: "NULL",
+      expected: {
+        text: "NULL",
+        json: null,
+      },
+    },
+    {
       name: "is null",
       input: "geometry IS NULL",
       expected: {

--- a/src/logic/parser/parseText.test.ts
+++ b/src/logic/parser/parseText.test.ts
@@ -9,7 +9,7 @@ describe("Test parsing tokens (text)", () => {
       name: "Empty, just EOF",
       input: "",
       expected: {
-        string: "",
+        text: "",
         json: "",
       },
     },
@@ -17,7 +17,7 @@ describe("Test parsing tokens (text)", () => {
       name: "number",
       input: "123",
       expected: {
-        string: "123",
+        text: "123",
         json: 123,
       },
     },
@@ -25,7 +25,7 @@ describe("Test parsing tokens (text)", () => {
       name: "decimal number",
       input: "123.456",
       expected: {
-        string: "123.456",
+        text: "123.456",
         json: 123.456,
       },
     },
@@ -33,7 +33,7 @@ describe("Test parsing tokens (text)", () => {
       name: "negative number",
       input: "-456",
       expected: {
-        string: "-456",
+        text: "-456",
         json: -456,
       },
     },
@@ -41,15 +41,23 @@ describe("Test parsing tokens (text)", () => {
       name: "string (wrapped in quotes)",
       input: "'hello world'",
       expected: {
-        string: "hello world",
+        text: "'hello world'",
         json: "hello world",
+      },
+    },
+    {
+      name: "strings",
+      input: "'foo' <> 'bar'",
+      expected: {
+        text: "'foo' <> 'bar'",
+        json: { op: "<>", args: ["foo", "bar"] },
       },
     },
     {
       name: "addition",
       input: "3+4",
       expected: {
-        string: "3 + 4",
+        text: "3 + 4",
         json: { op: "+", args: [3, 4] },
       },
     },
@@ -57,7 +65,7 @@ describe("Test parsing tokens (text)", () => {
       name: "subtraction",
       input: "5-6",
       expected: {
-        string: "5 - 6",
+        text: "5 - 6",
         json: { op: "-", args: [5, 6] },
       },
     },
@@ -65,7 +73,7 @@ describe("Test parsing tokens (text)", () => {
       name: "addition of negative number",
       input: "5 + -6",
       expected: {
-        string: "5 + -6",
+        text: "5 + -6",
         json: { op: "+", args: [5, -6] },
       },
     },
@@ -73,7 +81,7 @@ describe("Test parsing tokens (text)", () => {
       name: "subtracting a property",
       input: "vehicle_height > (bridge_clearance - 1)",
       expected: {
-        string: "vehicle_height > (bridge_clearance - 1)",
+        text: "vehicle_height > (bridge_clearance - 1)",
         json: {
           op: ">",
           args: [
@@ -97,7 +105,7 @@ describe("Test parsing tokens (text)", () => {
       name: "is null",
       input: "geometry IS NULL",
       expected: {
-        string: "geometry IS NULL",
+        text: "geometry IS NULL",
         json: { op: "isNull", args: [{ property: "geometry" }] },
       },
     },
@@ -105,7 +113,7 @@ describe("Test parsing tokens (text)", () => {
       name: "is not null",
       input: "geometry IS NOT NULL",
       expected: {
-        string: "geometry IS NOT NULL",
+        text: "geometry IS NOT NULL",
         json: { op: "not", args: [{ op: "isNull", args: [{ property: "geometry" }] }] },
       },
     },
@@ -113,7 +121,7 @@ describe("Test parsing tokens (text)", () => {
       name: "calendar date",
       input: "DATE('1999-11-05')",
       expected: {
-        string: "DATE('1999-11-05')",
+        text: "DATE('1999-11-05')",
         json: { date: "1999-11-05" },
       },
     },
@@ -121,7 +129,7 @@ describe("Test parsing tokens (text)", () => {
       name: "timestamp",
       input: "TIMESTAMP('1999-01-15T13:45:23.000Z')",
       expected: {
-        string: "TIMESTAMP('1999-01-15T13:45:23.000Z')",
+        text: "TIMESTAMP('1999-01-15T13:45:23.000Z')",
         json: { timestamp: "1999-01-15T13:45:23.000Z" },
       },
     },
@@ -129,7 +137,7 @@ describe("Test parsing tokens (text)", () => {
       name: "order of precedence",
       input: "3 * 1 + 2",
       expected: {
-        string: "3 * 1 + 2",
+        text: "3 * 1 + 2",
         json: { op: "+", args: [{ op: "*", args: [3, 1] }, 2] },
       },
     },
@@ -137,35 +145,35 @@ describe("Test parsing tokens (text)", () => {
       name: "grouping",
       input: "2*(3+1)",
       expected: {
-        string: "2 * (3 + 1)",
+        text: "2 * (3 + 1)",
         json: { op: "*", args: [2, { op: "+", args: [3, 1] }] },
       },
     },
     {
       name: "function over literals",
       input: "add ( 4 , 5 )",
-      expected: { string: "add(4, 5)", json: { op: "add", args: [4, 5] } },
+      expected: { text: "add(4, 5)", json: { op: "add", args: [4, 5] } },
     },
     {
       name: "function over property",
       input: "avg ( windSpeed )",
-      expected: { string: "avg(windSpeed)", json: { op: "avg", args: [{ property: "windSpeed" }] } },
+      expected: { text: "avg(windSpeed)", json: { op: "avg", args: [{ property: "windSpeed" }] } },
     },
     {
       name: "comparison with property",
       input: "cloudCoverage>=50",
-      expected: { string: "cloudCoverage >= 50", json: { op: ">=", args: [{ property: "cloudCoverage" }, 50] } },
+      expected: { text: "cloudCoverage >= 50", json: { op: ">=", args: [{ property: "cloudCoverage" }, 50] } },
     },
     {
       name: "comparison with property other direction",
       input: "50>= cloudCoverage",
-      expected: { string: "50 >= cloudCoverage", json: { op: ">=", args: [50, { property: "cloudCoverage" }] } },
+      expected: { text: "50 >= cloudCoverage", json: { op: ">=", args: [50, { property: "cloudCoverage" }] } },
     },
     {
       name: "arithmetic has higher precedence than comparisons",
       input: "cloudCoverage >= 10+20",
       expected: {
-        string: "cloudCoverage >= 10 + 20",
+        text: "cloudCoverage >= 10 + 20",
         json: { op: ">=", args: [{ property: "cloudCoverage" }, { op: "+", args: [10, 20] }] },
       },
     },
@@ -173,7 +181,7 @@ describe("Test parsing tokens (text)", () => {
       name: "arithmetic has higher precedence than comparisons other direction",
       input: "10+20 >= cloudCoverage",
       expected: {
-        string: "10 + 20 >= cloudCoverage",
+        text: "10 + 20 >= cloudCoverage",
         json: { op: ">=", args: [{ op: "+", args: [10, 20] }, { property: "cloudCoverage" }] },
       },
     },
@@ -181,7 +189,7 @@ describe("Test parsing tokens (text)", () => {
       name: "equal",
       input: "3=(2 + 1)",
       expected: {
-        string: "3 = (2 + 1)",
+        text: "3 = (2 + 1)",
         json: { op: "=", args: [3, { op: "+", args: [2, 1] }] },
       },
     },
@@ -189,7 +197,7 @@ describe("Test parsing tokens (text)", () => {
       name: "not equal",
       input: "4 <> 5 ",
       expected: {
-        string: "4 <> 5",
+        text: "4 <> 5",
         json: { op: "<>", args: [4, 5] },
       },
     },
@@ -197,15 +205,47 @@ describe("Test parsing tokens (text)", () => {
       name: "booleans",
       input: "TRUE<>FALSE",
       expected: {
-        string: "TRUE <> FALSE",
+        text: "TRUE <> FALSE",
         json: { op: "<>", args: [true, false] },
+      },
+    },
+    {
+      name: "and",
+      input: "'foo' AND 'bar'",
+      expected: {
+        text: "'foo' AND 'bar'",
+        json: { op: "and", args: ["foo", "bar"] },
+      },
+    },
+    {
+      name: "or",
+      input: "'foo' OR 'bar'",
+      expected: {
+        text: "'foo' OR 'bar'",
+        json: { op: "or", args: ["foo", "bar"] },
+      },
+    },
+    {
+      name: "precedence - or before and",
+      input: "'foo' OR 'bar' AND 'baz'",
+      expected: {
+        text: "'foo' OR 'bar' AND 'baz'",
+        json: { op: "or", args: ["foo", { op: "and", args: ["bar", "baz"] }] },
+      },
+    },
+    {
+      name: "precedence - and before or",
+      input: "'foo' AND 'bar' OR 'baz'",
+      expected: {
+        text: "'foo' AND 'bar' OR 'baz'",
+        json: { op: "or", args: [{ op: "and", args: ["foo", "bar"] }, "baz"] },
       },
     },
   ];
 
   test.each(tests)("Parse with $name", ({ input, expected }) => {
     const parsed = parseText(scanText(input));
-    expect(parsed.toText()).toStrictEqual(expected.string);
+    expect(parsed.toText()).toStrictEqual(expected.text);
     expect(parsed.toJSON()).toStrictEqual(expected.json);
   });
 

--- a/src/logic/parser/parseText.ts
+++ b/src/logic/parser/parseText.ts
@@ -119,11 +119,14 @@ export default function parseText(tokens: Token[]): Expression {
   }
 
   function unary(): Expression {
-    if (match("MINUS")) {
-      const operator = previous();
-      const right = unary();
-      return new UnaryExpression(new OperatorExpression(operator), right);
-    }
+    // ATM unary doesn't exists, because minus before number is scanned as negative number,
+    // and NOT operator is handled at higher precedence.
+    // Keeping code here for future expansion.
+    // if (match("MINUS")) {
+    //   const operator = previous();
+    //   const right = unary();
+    //   return new UnaryExpression(new OperatorExpression(operator), right);
+    // }
 
     return primary();
   }

--- a/src/logic/parser/parseText.ts
+++ b/src/logic/parser/parseText.ts
@@ -42,15 +42,25 @@ export default function parseText(tokens: Token[]): Expression {
   }
 
   function and() {
-    let expr = equality();
+    let expr = not();
 
     while (match("AND")) {
       const operator: Token = previous();
-      const right = equality();
+      const right = not();
       expr = new BinaryExpression(expr, new OperatorExpression(operator), right);
     }
 
     return expr;
+  }
+
+  function not() {
+    if (match("NOT")) {
+      const operator = previous();
+      const right = unary();
+      return new UnaryExpression(new OperatorExpression(operator), right);
+    }
+
+    return equality();
   }
 
   function equality(): Expression {

--- a/src/logic/parser/parseText.ts
+++ b/src/logic/parser/parseText.ts
@@ -25,6 +25,22 @@ export default function parseText(tokens: Token[]): Expression {
   }
   return expression();
 
+  /**
+   * expression is the first function in precedence chain. Precedence chains in ascending order,
+   * while the "Grammar" chains in descending order. The Grammar is what you will see below.
+   * This is implicitly described in CQL2 BNF https://docs.ogc.org/DRAFTS/21-065r3.html#cql2-bnf
+   *
+   * Non-comprehensive precedence, ascending:
+   * logical or
+   * logical and
+   * negation (NOT)
+   * equality (equal, not equal)
+   * comparison (greater than, smaller than, etc.)
+   * arithmetic plus and minus
+   * arithmetic multiplication and division
+   * unary operators
+   * primary literals (numbers, string, booleans, properties, dates, etc.)
+   */
   function expression(): Expression {
     return or();
   }

--- a/src/logic/scanner/scanText.test.ts
+++ b/src/logic/scanner/scanText.test.ts
@@ -237,6 +237,26 @@ describe("Test scanning text", () => {
         new Token(43, "EOF", ""),
       ],
     },
+    {
+      name: "and",
+      input: "foo AND bar",
+      expected: [
+        new Token(0, "IDENTIFIER", "foo"),
+        new Token(4, "AND", "AND"),
+        new Token(8, "IDENTIFIER", "bar"),
+        new Token(11, "EOF", ""),
+      ],
+    },
+    {
+      name: "or",
+      input: "foo OR bar",
+      expected: [
+        new Token(0, "IDENTIFIER", "foo"),
+        new Token(4, "OR", "OR"),
+        new Token(7, "IDENTIFIER", "bar"),
+        new Token(10, "EOF", ""),
+      ],
+    },
   ];
 
   test.each(tests)("Expression with $name", ({ input, expected }) => {

--- a/src/logic/scanner/scanText.ts
+++ b/src/logic/scanner/scanText.ts
@@ -1,5 +1,5 @@
 import Token from "../Entities/Token";
-import type TokenType from "../Entities/TokenType";
+import type { TokenType } from "../Entities/TokenType";
 import { DATE_FORMATS, TIMESTAMP_FORMATS } from "../Time/time";
 import ScanError from "./scanError";
 
@@ -9,6 +9,8 @@ export default function scanText(input: string): Token[] {
   const literalWrapper = "'";
 
   const keywords: Record<string, TokenType> = {
+    AND: "AND",
+    OR: "OR",
     IS: "IS",
     NOT: "NOT",
     NULL: "NULL",


### PR DESCRIPTION
Handle AND, OP, and NOT operators. ATM they are binary operators, so `'a' AND 'b' AND 'c'`, `{ op: "and", args: ["a", "a"] }` works, but more operands don't `{ op: "and", args: ["foo", "bar", "baz"] }`.

Other changes
* OperatorExpression accepts Token and not string like before. This is because it needs access to both the token type for known operators (AND, OR, +, -, etc.) and lexeme for unknown operators (functions)
* Operator metada is used in OperatorExpression
* Expressions are immutable
* Fixed a bunch of tests, added a bunch of tests. Coverage increased to ~99% 💪 

